### PR TITLE
Remove 0.0.0.0 DNS record in favour of `always_refuse`

### DIFF
--- a/build.js
+++ b/build.js
@@ -36,7 +36,7 @@ class Blacklist {
       {
         type: 'unbound',
         filename: 'unbound.blacklist',
-        template: 'local-zone: "<%= host %>" refuse'
+        template: 'local-zone: "<%= host %>" always_refuse'
       },
       {
         type: 'unbound',

--- a/build.js
+++ b/build.js
@@ -36,7 +36,7 @@ class Blacklist {
       {
         type: 'unbound',
         filename: 'unbound.blacklist',
-        template: 'local-zone: "<%= host %>" redirect\nlocal-data: "<%= host %> A 0.0.0.0"'
+        template: 'local-zone: "<%= host %>" refuse'
       },
       {
         type: 'unbound',


### PR DESCRIPTION
Current implementation is consuming too much memory when unbound re-initiates DNS validation, on the other hand `always_refuse` is way cheaper.

More info here:
https://wiki.archlinux.org/index.php/unbound#Domain_blacklisting